### PR TITLE
Upgrade Elixir to 1.3.0

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -13,7 +13,16 @@ RUN apt-get update && \
   erlang \
   erlang-dev \
   erlang-doc \
-  erlang-src \
-  elixir
+  erlang-src
+
+RUN mkdir /build
+RUN cd /build \
+  && wget --quiet \
+  https://github.com/elixir-lang/elixir/archive/v1.3.0.tar.gz \
+  && echo "66cb8448dd60397cad11ba554c2613f732192c9026468cff55e8347a5ae4004a v1.3.0.tar.gz" \
+  | sha256sum -c - \
+  && tar -xf v1.3.0.tar.gz \
+  && cd elixir-1.3.0 \
+  && make install
 
 CMD iex


### PR DESCRIPTION
This upgrades Elixir to 1.3.0 by building from source via the source on
Github.

The download is verified by the SHA256 provided on build. I verified the
SHA256 manually and also checked it against
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=54b66f9d65b1931459fe9f04481044f8553a54ca
